### PR TITLE
Multiple peripherals removed on clear

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -893,12 +893,12 @@
             NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
         }
     }
-    for(id key in noticiationCallbacks.allKeys) {
+    for(id key in notificationCallbacks.allKeys) {
         if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
             NSString *callbackId = [notificationCallbacks valueForKey:key];
             [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-            [notificaitonCallbacks removeObjectForKey:key]
-            NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
+            [notificationCallbacks removeObjectForKey:key]
+            NSLog(@"Cleared notification callback %@ for key %@", callbackId, key);
         }
     }
 }

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -893,7 +893,14 @@
             NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
         }
     }
-    [notificationCallbacks removeAllObjects];
+    for(id key in noticiationCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [notificationCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [notificaitonCallbacks removeObjectForKey:key]
+            NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
+        }
+    }
 }
 
 #pragma mark - util

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -897,7 +897,7 @@
         if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
             NSString *callbackId = [notificationCallbacks valueForKey:key];
             [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-            [notificationCallbacks removeObjectForKey:key]
+            [notificationCallbacks removeObjectForKey:key];
             NSLog(@"Cleared notification callback %@ for key %@", callbackId, key);
         }
     }


### PR DESCRIPTION
cleanupOperationCallbacks() now only removes the specific callback for the peripheral instead of all.